### PR TITLE
Bug fix to allow only a subset of wires to be measured

### DIFF
--- a/pennylane_qsharp/device.py
+++ b/pennylane_qsharp/device.py
@@ -51,6 +51,8 @@ operation Program () : Bool[] {{
         {operations}
         // measurements
         {measurements}
+        // reset all qubits
+        ResetAll(q);
     }}
     return BoolArrFromResultArr(resultArray);
 }}

--- a/pennylane_qsharp/quantum_simulator.py
+++ b/pennylane_qsharp/quantum_simulator.py
@@ -46,7 +46,7 @@ class QuantumSimulatorDevice(QSharpDevice):
             to estimate expectation values of expectations.
         noisy (bool): set to ``True`` to add noise models to your QVM.
     """
-    name = 'Microsoft Q# full state simulatord device'
+    name = 'Microsoft Q# full state simulator device'
     short_name = 'microsoft.QuantumSimulator'
 
     def pre_expval(self):


### PR DESCRIPTION
Fixes a bug in the compiled Q# code. No manual reset of qubits was being performed --- this caused an error if only a subset of the qubits are measured.