### PR TITLE
PennyLane v0.4 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Features
   This provides access to the local full state simulator.
 
 
-* All provided devices support all core qubit PennyLane operations and expectation values.
+* All provided devices support all core qubit PennyLane operations and observables.
 
 
 * Provides custom PennyLane operations to cover additional Q# operations, including

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,7 +25,7 @@ Features
   This provides access to the local full state simulator.
 
 
-* All provided devices support all core qubit PennyLane operations and expectation values.
+* All provided devices support all core qubit PennyLane operations and observables.
 
 
 * Provides custom PennyLane operations to cover additional Q# operations, including

--- a/pennylane_qsharp/_version.py
+++ b/pennylane_qsharp/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.1.0'
+__version__ = '0.2.0'

--- a/pennylane_qsharp/device.py
+++ b/pennylane_qsharp/device.py
@@ -51,6 +51,8 @@ operation Program () : Bool[] {{
         {operations}
         // measurements
         {measurements}
+        // reset all qubits
+        ResetAll(q);
     }}
     return BoolArrFromResultArr(resultArray);
 }}

--- a/pennylane_qsharp/quantum_simulator.py
+++ b/pennylane_qsharp/quantum_simulator.py
@@ -43,17 +43,20 @@ class QuantumSimulatorDevice(QSharpDevice):
 
     Args:
         shots (int): number of circuit evaluations/random samples used
-            to estimate expectation values of expectations.
+            to estimate expectation values of observables.
         noisy (bool): set to ``True`` to add noise models to your QVM.
     """
     name = 'Microsoft Q# full state simulator device'
     short_name = 'microsoft.QuantumSimulator'
 
-    def pre_expval(self):
+    def pre_measure(self):
         """Run the simulator"""
         # pylint: disable=attribute-defined-outside-init
         for i in range(self.shots):
             self.results.append([1-2*int(i) for i in self.qs.simulate()])
 
-    def expval(self, expectation, wires, par):
+    def expval(self, observable, wires, par):
         return np.mean(np.array(self.results).T[wires[0]])
+
+    def var(self, observable, wires, par):
+        return np.var(np.array(self.results).T[wires[0]])

--- a/pennylane_qsharp/quantum_simulator.py
+++ b/pennylane_qsharp/quantum_simulator.py
@@ -46,7 +46,7 @@ class QuantumSimulatorDevice(QSharpDevice):
             to estimate expectation values of expectations.
         noisy (bool): set to ``True`` to add noise models to your QVM.
     """
-    name = 'Microsoft Q# full state simulatord device'
+    name = 'Microsoft Q# full state simulator device'
     short_name = 'microsoft.QuantumSimulator'
 
     def pre_expval(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 qsharp
-pennylane>=0.3
+pennylane>=0.4

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ with open("pennylane_qsharp/_version.py") as f:
 
 
 requirements = [
-    "qsharp"
+    "qsharp",
+    "pennylane>=0.4"
 ]
 
 


### PR DESCRIPTION
This PR includes the following changes:

* Bumps the plugin version number to v0.2

* Adds support for PennyLane version 0.4. This includes:

  - Renaming `expectation` -> `observable` in various places in the documentation
  - `Device.expectations` -> `Device.observables`
  - `Device.pre_expval` -> `Device.pre_measure`

* Bumps the required PennyLane version to >=0.4

* Adds support for observable variance

Once this PR is merged, I will update the PyPI release.
