### PR TITLE
Updating PROGRAM such that no deprecated methods are used

### DIFF
--- a/pennylane_qsharp/device.py
+++ b/pennylane_qsharp/device.py
@@ -101,7 +101,7 @@ class QSharpDevice(Device):
             to estimate expectation values of observables.
             For simulator devices, 0 means the exact EV is returned.
     """
-    pennylane_requires = '>=0.4'
+    pennylane_requires = '>=0.6'
     version = __version__
     author = 'Josh Izaac'
 

--- a/pennylane_qsharp/device.py
+++ b/pennylane_qsharp/device.py
@@ -43,7 +43,10 @@ from pennylane import Device
 from ._version import __version__
 
 
-PROGRAM = """\
+PROGRAM = """
+open Microsoft.Quantum.Convert;
+open Microsoft.Quantum.Measurement;
+
 operation Program () : Bool[] {{
     mutable resultArray = new Result[{wires}];
     using (q = Qubit[{wires}]) {{
@@ -54,7 +57,7 @@ operation Program () : Bool[] {{
         // reset all qubits
         ResetAll(q);
     }}
-    return BoolArrFromResultArr(resultArray);
+    return ResultArrayAsBoolArray(resultArray);
 }}
 """
 
@@ -125,7 +128,7 @@ class QSharpDevice(Device):
     def post_apply(self): #pragma no cover
         """Compile the Q# program"""
         for e in self.obs_queue:
-            self.measure += "set resultArray[{wires[0]}] = ".format(wires=e.wires)
+            self.measure += "set resultArray w/= {wires[0]} <- ".format(wires=e.wires)
             self.measure += self._observable_map[e.name].format(p=e.parameters, wires=e.wires)
             self.measure += "            "
 
@@ -143,10 +146,6 @@ class QSharpDevice(Device):
         self._source_code = ""
         self.qs = None
         self.results = []
-
-    @property
-    def operations(self):
-        return set(self._operation_map.keys())
 
     @property
     def operations(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 qsharp
-pennylane>=0.4
+pennylane>=0.6.0


### PR DESCRIPTION
Currently, as there were modifications in Q#, the previous implementation of the plugin results in errors when running.

This change updates how the ``PROGRAM`` is being built with the new syntax in Q#.

It is worth noting that each run using Q# might emit socket error messages. This is a known error for which [more details can be found here](https://github.com/microsoft/iqsharp/issues/39).