### PR TITLE
Adding the capabilities dictionary with the qubit model

### DIFF
--- a/pennylane_qsharp/device.py
+++ b/pennylane_qsharp/device.py
@@ -108,6 +108,8 @@ class QSharpDevice(Device):
     _operation_map = qsharp_operation_map
     _observable_map = qsharp_observable_map
 
+    _capabilities = {"model": 'qubit'}
+
     def __init__(self, wires, shots=1024, **kwargs):
         if shots <= 0:
             raise ValueError("Number of shots must be a positive integer.")


### PR DESCRIPTION
Currently ``QNode`` takes advantage of ``_capabilities`` defined of the specific device.

This was so far not added to ``QSharpDevice``.

This PR adds the dictionary.

Can be checked with a simple example:

```python
import pennylane as qml  
dev = qml.device('microsoft.QuantumSimulator', wires=2, shots=1000)                                                                                                                         
@qml.qnode(dev)  
def circuit():  
    qml.PauliX(0)  
    return qml.expval(qml.PauliZ(0))  
```